### PR TITLE
fix: do not add leading and trailing slashes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -134,7 +134,7 @@ resource "aws_lambda_function" "slowlog_check" {
   environment {
     variables = {
       REDIS_HOST = var.elasticache_endpoint
-      SSM_PATH   = "/${var.ssm_path}/"
+      SSM_PATH   = "${var.ssm_path}"
       NAMESPACE  = var.namespace
       ENV        = var.env
       METRICNAME = var.metric_name


### PR DESCRIPTION
Fixes this error: 
```
"errorMessage": "User: arn:aws:sts::1234567890:assumed-role/slowlog_check/slowlog_check is not authorized to perform: ssm:GetParametersByPath on resource: arn:aws:ssm:us-east-2:1234567890:parameter//slowlog_check//",
```