### PR TITLE
fix: Support primary endpoint URL format

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -3,7 +3,8 @@ locals {
   slowlog_check_archive_hash     = "H2YmQMqSwV8uSC6TXVJJLykkYUTj1e+g8Bi9Nijiex4="
   slowlog_check_archive_path     = "${path.module}/files/${local.slowlog_check_archive_basename}"
 
-  search_replication_group    = "(?P<first>[0-9A-Za-z_-]+)\\.(?P<second>[0-9A-Za-z_-]+)\\.{0,1}(?P<third>[0-9A-Za-z_]*)\\.(?P<region>[0-9A-Za-z_-]+)\\.cache\\.amazonaws\\.com:{0,1}(?P<port>[0-9]*)"
+  # https://pythex.org/?regex=(%3FP%3Cfirst%3E%5B0-9A-Za-z_-%5D%2B)%5C.(%3FP%3Csecond%3E%5B0-9A-Za-z_-%5D%2B)%5C.%7B0%2C1%7D(%3FP%3Cthird%3E%5B0-9A-Za-z_%5D*)%5C.%7B0%2C1%7D(%3FP%3Cfourth%3E%5B0-9A-Za-z_%5D*)%5C.(%3FP%3Cregion%3E%5B0-9A-Za-z_-%5D%2B)%5C.cache%5C.amazonaws%5C.com%3A%7B0%2C1%7D(%3FP%3Cport%3E%5B0-9%5D*)&test_string=cluster-one.abcdef.0001.use1.cache.amazonaws.com%3A6379%0Acluster-two.abcdef.ng.0001.use1.cache.amazonaws.com%3A6379%0Amaster.cluster-three.abcdef.use1.cache.amazonaws.com%3A6379%0A&ignorecase=0&multiline=0&dotall=0&verbose=0
+  search_replication_group    = "(?P<first>[0-9A-Za-z_-]+)\\.(?P<second>[0-9A-Za-z_-]+)\\.{0,1}(?P<third>[0-9A-Za-z_]*)\\.{0,1}(?P<fourth>[0-9A-Za-z_]*)\\.(?P<region>[0-9A-Za-z_-]+)\\.cache\\.amazonaws\\.com:{0,1}(?P<port>[0-9]*)"
   parsed_elasticache_endpoint = regex(local.search_replication_group, var.elasticache_endpoint)
   # https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Endpoints.html
   replication_group = contains(["clustercfg", "master"], local.parsed_elasticache_endpoint["first"]) ? local.parsed_elasticache_endpoint["second"] : local.parsed_elasticache_endpoint["first"]


### PR DESCRIPTION
This PR changes the replication group regex to support the URLs returned by the  [`elasticache_replication_group.primary_endpoint_address`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_replication_group#primary_endpoint_address) terraform attribute. For our clusters that looks like (note the extra "ng" segment):

```
cluster-one.abcdef.ng.0001.use1.cache.amazonaws.com:6379
cluster-two.abcdef.ng.0001.use1.cache.amazonaws.com:6379
cluster-three.abcdef.ng.0001.use1.cache.amazonaws.com:6379
```

The current regex is setting `replication_group` to "abcdef" rather than the actual cluster name, and thus preventing us from using this module for more than one cluster.

To fix this, I added an optional fourth capture group. This should be [backwards compatible w/ the existing regex](https://pythex.org/?regex=(%3FP%3Cfirst%3E%5B0-9A-Za-z_-%5D%2B)%5C.(%3FP%3Csecond%3E%5B0-9A-Za-z_-%5D%2B)%5C.%7B0%2C1%7D(%3FP%3Cthird%3E%5B0-9A-Za-z_%5D*)%5C.%7B0%2C1%7D(%3FP%3Cfourth%3E%5B0-9A-Za-z_%5D*)%5C.(%3FP%3Cregion%3E%5B0-9A-Za-z_-%5D%2B)%5C.cache%5C.amazonaws%5C.com%3A%7B0%2C1%7D(%3FP%3Cport%3E%5B0-9%5D*)&test_string=cluster-one.abcdef.0001.use1.cache.amazonaws.com%3A6379%0Acluster-two.abcdef.ng.0001.use1.cache.amazonaws.com%3A6379%0Amaster.cluster-three.abcdef.use1.cache.amazonaws.com%3A6379%0A&ignorecase=0&multiline=0&dotall=0&verbose=0).
