### PR TITLE
bump lambda runtime ruby version 2.5 -> 2.7

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -117,7 +117,7 @@ resource "aws_lambda_function" "slowlog_check" {
   source_code_hash = local.slowlog_check_archive_hash
   role             = aws_iam_role.slowlog_check.arn
   handler          = "lambda_function.lambda_handler"
-  runtime          = "ruby2.5"
+  runtime          = "ruby2.7"
   vpc_config {
     subnet_ids         = var.subnet_ids
     security_group_ids = concat([aws_security_group.egress.id], var.elasticache_security_groups)


### PR DESCRIPTION
We are unable to create new Lamdba functions with our current runtime configuration of ruby v2.5 (EOL). This pr bumps the ruby version up to 2.7 which should unblock the creation.

Buildkite of attempted Terraform apply blocked by ruby runtime version:
https://buildkite.com/opcity/opcity-terraform/builds/1015#018172a3-01e6-4c3f-b609-d8c1dc534905