### PR TITLE
COREINF-7108: providing a hostname ourself

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -131,6 +131,7 @@ resource "aws_lambda_function" "slowlog_check" {
       NAMESPACE  = var.namespace
       ENV        = var.env
       METRICNAME = var.metric_name
+      DD_HOSTNAME = "slowlog-check-${local.replication_group}"
     }
   }
 


### PR DESCRIPTION
this is the fix for:
```
{
    "errorMessage": "No such file or directory - hostname",
    "errorType": "Function<Errno::ENOENT>",
    "stackTrace": [
        "/var/lang/lib/ruby/2.7.0/open3.rb:213:in `spawn'",
        "/var/lang/lib/ruby/2.7.0/open3.rb:213:in `popen_run'",
        "/var/lang/lib/ruby/2.7.0/open3.rb:159:in `popen2'",
        "/var/lang/lib/ruby/2.7.0/open3.rb:342:in `capture2'",
        "/var/task/vendor/bundle/ruby/2.7.0/gems/dogapi-1.45.0/lib/dogapi/common.rb:218:in `find_localhost'",
        "/var/task/vendor/bundle/ruby/2.7.0/gems/dogapi-1.45.0/lib/dogapi/facade.rb:78:in `initialize'",
        "/var/task/lambda_function.rb:48:in `new'",
        "/var/task/lambda_function.rb:48:in `lambda_handler'"
    ]
}
```