### PR TITLE
chore: DEVPLAT-7373 fix Node.js 20 deprecated GitHub Actions

### DIFF
--- a/.github/workflows/validate_and_release.yml
+++ b/.github/workflows/validate_and_release.yml
@@ -44,7 +44,7 @@ jobs:
     - uses: actions/checkout@v6
     - name: Semantic Release
       id: semantic
-      uses: cycjimmy/semantic-release-action@v6
+      uses: cycjimmy/semantic-release-action@v5
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/validate_and_release.yml
+++ b/.github/workflows/validate_and_release.yml
@@ -48,7 +48,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        semantic_version: 19
+        semantic_version: 24
         extra_plugins: |
           @semantic-release/changelog
           @semantic-release/git

--- a/.github/workflows/validate_and_release.yml
+++ b/.github/workflows/validate_and_release.yml
@@ -44,7 +44,7 @@ jobs:
     - uses: actions/checkout@v6
     - name: Semantic Release
       id: semantic
-      uses: cycjimmy/semantic-release-action@v5
+      uses: cycjimmy/semantic-release-action@v6
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/validate_and_release.yml
+++ b/.github/workflows/validate_and_release.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: 'Terraform Format'
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: ${{ matrix.terraform }}
       
@@ -44,7 +44,7 @@ jobs:
     - uses: actions/checkout@v6
     - name: Semantic Release
       id: semantic
-      uses: cycjimmy/semantic-release-action@v4
+      uses: cycjimmy/semantic-release-action@v5
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:


### PR DESCRIPTION
## Summary

Upgrades GitHub Actions that use the deprecated Node.js 20 runtime to Node.js 24 compatible versions.

Node.js 20 actions will be forced to run on Node.js 24 by default starting **June 2nd, 2026**. See the [GitHub deprecation notice](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

**Changes made:**
- `cycjimmy/semantic-release-action@v4` → `cycjimmy/semantic-release-action@v5`
- `hashicorp/setup-terraform@v3` → `hashicorp/setup-terraform@v4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DEVPLAT-7373](https://scribd.atlassian.net/browse/DEVPLAT-7373)


[DEVPLAT-7373]: https://scribdjira.atlassian.net/browse/DEVPLAT-7373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the CI release workflow dependencies (Terraform setup and semantic-release) to new major versions, which could change release behavior or tooling defaults despite no product code changes.
> 
> **Overview**
> Updates the `validate_and_release.yml` GitHub Actions workflow to use newer, Node.js 24-compatible action versions.
> 
> Bumps `hashicorp/setup-terraform` to `v4` for the Terraform matrix job and upgrades `cycjimmy/semantic-release-action` to `v5` while also moving `semantic_version` from `19` to `24` for the release step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b2a133bcbeccac8f2d1f8d16078bbf86c5b0517. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->